### PR TITLE
Replace old OSM tile server with new one

### DIFF
--- a/resources/views/sights/map_js.blade.php
+++ b/resources/views/sights/map_js.blade.php
@@ -2,8 +2,8 @@
 
     var map = L.map('map');
 
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         maxZoom: 18,
     }).addTo(map);
 

--- a/resources/views/sights/show.blade.php
+++ b/resources/views/sights/show.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('content')
- 
+
 @include('sights.show_partial',['h1'=>true])
 
 <div class="row">
@@ -27,9 +27,8 @@
             mapSelector = 'mobile-map';
         }
         var map = L.map(mapSelector).setView(latlng, 13);
-        //L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/1/1/0?access_token={{env('MAPBOX_TOKEN')}}', {
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             maxZoom: 18,
         }).addTo(map);
 


### PR DESCRIPTION
Змінено застарілий тайловий сервер OSM `(a|b|c).tile.openstreetmap.org` на новий `tile.openstreetmap.org`, оскільки старі URL-адреси можуть бути [деактивовані](https://github.com/openstreetmap/operations/issues/737) у будь-який час.

Видалено копірайт на тайли MapBox які не використовуються.

Див.

- https://twitter.com/OSM_Tech/status/1564685832300134402